### PR TITLE
Dockerfile: Disable libglesv2 in wine to avoid black windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,8 @@ RUN winetricks -q corefonts
 WORKDIR /fitbitos
 RUN wget -O fitbitos.exe "https://simulator-updates.fitbit.com/Fitbit OS Simulator-latest-0.9.0.exe" 
 
-# Disable GL acceleration, it just creates black windows in most setup
-ENV LIBGL_ALWAYS_SOFTWARE=1
+# Disable libglesv2, it just creates black windows in most setup (https://bugs.winehq.org/show_bug.cgi?id=44985)
+ENV WINEDLLOVERRIDES=libglesv2=d
 
 # starter script
 COPY start.sh /root


### PR DESCRIPTION
As per https://bugs.winehq.org/show_bug.cgi?id=44985

Especially with newer wine (6) just forcing software render didn't work here, while this seems to be enough and allow to still use hw rendering with basic GL.